### PR TITLE
pip install broken by import in setup.py

### DIFF
--- a/alab_management/__init__.py
+++ b/alab_management/__init__.py
@@ -2,7 +2,7 @@
 Managing everything in the autonomous lab.
 """
 
-__version__ = "0.4.1"
+# __version__ = "0.4.1"
 
 from .device_view.device import BaseDevice, add_device
 from .sample_view import Sample, SamplePosition

--- a/setup.py
+++ b/setup.py
@@ -2,24 +2,27 @@ from pathlib import Path
 
 from setuptools import setup, find_packages
 
-from alab_management import __version__
+# from alab_management import __version__
 
 setup(
     name="alab_management",
     packages=find_packages(exclude=["tests", "tests.*"]),
     package_data={"alab_management": ["py.typed"]},
-    version=__version__,
+    version="0.4.1",
     author="Alab Project Team",
     python_requires=">=3.6",
     description="Workflow management system for alab",
     zip_safe=False,
     install_requires=[
         package.strip("\n")
-        for package in (Path(__file__).parent / "requirements.txt").open("r", encoding="utf-8").readlines()],
+        for package in (Path(__file__).parent / "requirements.txt")
+        .open("r", encoding="utf-8")
+        .readlines()
+    ],
     include_package_data=True,
     entry_points={
         "console_scripts": [
             "alabos = alab_management.scripts.cli:cli",
         ]
-    }
+    },
 )


### PR DESCRIPTION
Fixes #14

Writing version number directly in setup.py to avoid import issues during `pip install`. will eventually move to a CI-based versioning scheme.