### PR TITLE
Rekumar/issue31

### DIFF
--- a/alab_management/lab_view.py
+++ b/alab_management/lab_view.py
@@ -20,7 +20,7 @@ from alab_management.experiment_view.experiment_view import ExperimentView
 from alab_management.logger import DBLogger
 from alab_management.sample_view.sample import Sample
 from alab_management.sample_view.sample_view import SampleView, SamplePositionRequest
-from alab_management.task_manager import ResourceRequester
+from alab_management.task_manager.resource_requester import ResourceRequester
 from alab_management.task_view.task import BaseTask
 from alab_management.task_view.task_enums import TaskPriority, TaskStatus
 from alab_management.task_view.task_view import TaskView

--- a/alab_management/scripts/cli.py
+++ b/alab_management/scripts/cli.py
@@ -1,7 +1,6 @@
 """
 Useful CLI tools for the alab_management package.
 """
-
 import click
 
 from .cleanup_lab import cleanup_lab

--- a/alab_management/scripts/launch_lab.py
+++ b/alab_management/scripts/launch_lab.py
@@ -38,7 +38,7 @@ def launch_experiment_manager():
 
 
 def launch_task_manager():
-    from ..task_manager import TaskManager
+    from ..task_manager.task_manager import TaskManager
     from ..utils.module_ops import load_definition
 
     load_definition()

--- a/alab_management/scripts/launch_worker.py
+++ b/alab_management/scripts/launch_worker.py
@@ -2,11 +2,17 @@
 Launch Dramatiq worker to submit tasks
 """
 
+from alab_management.task_manager.task_manager import TaskManager
+import os
+
 
 def launch_worker(args):
     from dramatiq.cli import main as launch
     from dramatiq.cli import make_argument_parser
     from argparse import Namespace
+
+    # Clean up any leftover tasks from previous runs. This blocks new workers until cleanup is done!
+    TaskManager()._clean_up_tasks_from_previous_runs()
 
     args = make_argument_parser().parse_args(
         args=["alab_management.task_actor"] + args,

--- a/alab_management/task_actor.py
+++ b/alab_management/task_actor.py
@@ -15,8 +15,6 @@ from dramatiq_abort import Abortable, backends, Abort
 from alab_management.logger import DBLogger
 from alab_management.sample_view import SampleView
 
-# from alab_management.task_view.task import BaseTask
-# from alab_management.task_view.task_view import TaskView
 from alab_management.task_view import BaseTask, TaskView, TaskStatus
 from alab_management.utils.data_objects import get_collection
 from alab_management.utils.module_ops import load_definition

--- a/alab_management/task_manager/__init__.py
+++ b/alab_management/task_manager/__init__.py
@@ -1,0 +1,2 @@
+from .resource_requester import ResourceRequester
+from .task_manager import TaskManager

--- a/alab_management/task_manager/__init__.py
+++ b/alab_management/task_manager/__init__.py
@@ -1,2 +1,2 @@
-from .resource_requester import ResourceRequester
-from .task_manager import TaskManager
+## vv DO NOT IMPORT TaskManager here! Causes circular import issues.
+# from .task_manager.task_manager import TaskManager

--- a/alab_management/task_manager/enums.py
+++ b/alab_management/task_manager/enums.py
@@ -1,0 +1,16 @@
+from enum import Enum, auto
+
+_EXTRA_REQUEST: str = "__nodevice"
+
+
+class RequestStatus(Enum):
+    """
+    The status for a request. It will be stored in the database
+    """
+
+    PENDING = auto()
+    FULFILLED = auto()
+    NEED_RELEASE = auto()
+    RELEASED = auto()
+    CANCELED = auto()
+    ERROR = auto()

--- a/alab_management/task_manager/resource_requester.py
+++ b/alab_management/task_manager/resource_requester.py
@@ -1,0 +1,362 @@
+"""
+TaskLauncher is the core module of the system,
+which actually executes the tasks
+"""
+import time
+from concurrent.futures import Future
+from datetime import datetime
+from threading import Thread
+from traceback import print_exc
+from typing import Union, Dict, Optional, Type, List, Any, cast
+
+import dill
+from bson import ObjectId
+from pydantic import BaseModel, root_validator
+
+from alab_management.sample_view.sample import SamplePosition
+
+from ..device_view.device import BaseDevice
+from ..sample_view.sample_view import SamplePositionRequest
+from ..task_view import TaskView, TaskPriority
+from ..utils.data_objects import get_collection
+from .enums import RequestStatus, _EXTRA_REQUEST
+
+_SampleRequestDict = Dict[str, int]
+_ResourceRequestDict = Dict[
+    Optional[Union[Type[BaseDevice], str]], List[_SampleRequestDict]
+]  # the raw request sent by task process
+
+
+
+
+class ResourcesRequest(BaseModel):
+    """
+    This class is used to validate the resource request. Each request should have a format of
+    [
+        {
+            "device":{
+                "identifier": "name" or "type" or "nodevice",
+                "content": string corresponding to identifier
+            },
+            "sample_positions": [
+                {
+                    "prefix": prefix of sample position,
+                    "number": integer number of such positions requested.
+                },
+                ...
+            ]
+        },
+        ...
+    ]
+
+    See Also:
+        :py:class:`SamplePositionRequest <alab_management.sample_view.sample_view.SamplePositionRequest>`
+    """
+
+    __root__: List[
+        Dict[str, Union[List[Dict[str, Union[str, int]]], Dict[str, str]]]
+    ]  # type: ignore
+
+    @root_validator(pre=True, allow_reuse=True)
+    def preprocess(cls, values):  # pylint: disable=no-self-use,no-self-argument
+        values = values["__root__"]
+
+        new_values = []
+        for request_dict in values:
+            if request_dict["device"]["identifier"] not in [
+                "name",
+                "type",
+                _EXTRA_REQUEST,
+            ]:
+                raise ValueError(
+                    f"device identifier must be one of 'name', 'type', or {_EXTRA_REQUEST}"
+                )
+            new_values.append(
+                {
+                    "device": {
+                        "identifier": request_dict["device"]["identifier"],
+                        "content": request_dict["device"]["content"],
+                    },
+                    "sample_positions": request_dict["sample_positions"],
+                }
+            )
+        return {"__root__": new_values}
+
+
+class RequestMixin:
+    """
+    Simple wrapper for the request collection
+    """
+
+    def __init__(self):
+        self._request_collection = get_collection("requests")
+
+    def update_request_status(self, request_id: ObjectId, status: RequestStatus):
+        return self._request_collection.update_one(
+            {"_id": request_id}, {"$set": {"status": status.name}}
+        )
+
+    def get_request(self, request_id: ObjectId, **kwargs):
+        return self._request_collection.find_one(
+            {"_id": request_id}, **kwargs
+        )  # DB_ACCESS_OUTSIDE_VIEW
+
+    def get_requests_by_status(self, status: RequestStatus):
+        return self._request_collection.find(
+            {"status": status.name}
+        )  # DB_ACCESS_OUTSIDE_VIEW
+
+    def get_requests_by_task_id(self, task_id: ObjectId):
+        return self._request_collection.find({"task_id": task_id})
+
+
+class ResourceRequester(RequestMixin):
+    """
+    Class for request lab resources easily. This class will insert a request into the database,
+    and then the task manager will read from the database and assign the resources.
+
+    It is used in :py:class:`~alab_management.lab_view.LabView`.
+    """
+
+    def __init__(
+        self,
+        task_id: ObjectId,
+    ):
+        self._request_collection = get_collection("requests")
+        self._waiting: Dict[ObjectId, Dict[str, Any]] = {}
+        self.task_id = task_id
+        self.priority: Union[
+            int, TaskPriority
+        ] = (
+            TaskPriority.NORMAL
+        )  # will usually be overwritten by BaseTask instantiation.
+
+        super().__init__()
+        self._thread = Thread(target=self._check_request_status_loop)
+        self._thread.daemon = False
+        self._thread.start()
+
+    def request_resources(
+        self,
+        resource_request: _ResourceRequestDict,
+        timeout: Optional[float] = None,
+        priority: Optional[Union[TaskPriority, int]] = None,
+    ) -> Dict[str, Any]:
+        """
+        Request lab resources. Write the request into the database, and then the task manager will read from the
+        database and assign the resources.
+        """
+
+        f = Future()
+        if priority is None:
+            priority = self.priority
+
+        formatted_resource_request = []
+
+        device_str_to_request = {}
+        for device, position_dict in resource_request.items():
+            if device is None:
+                identifier = _EXTRA_REQUEST
+                content = _EXTRA_REQUEST
+            elif isinstance(device, str):
+                identifier = "name"
+                content = device
+            elif issubclass(device, BaseDevice):
+                identifier = "type"
+                content = device.__name__
+            else:
+                raise ValueError(
+                    "device must be a name of a specific device, a class of type BaseDevice, or None"
+                )
+            device_str_to_request[content] = device
+
+            positions = [
+                dict(SamplePositionRequest(prefix=prefix, number=number))
+                for prefix, number in position_dict.items()
+            ]  # immediate dict conversion - SamplePositionRequest is only used to check request format.
+            formatted_resource_request.append(
+                {
+                    "device": {
+                        "identifier": identifier,
+                        "content": content,
+                    },
+                    "sample_positions": positions,
+                }
+            )
+
+        if not isinstance(formatted_resource_request, ResourcesRequest):
+            formatted_resource_request = ResourcesRequest(__root__=formatted_resource_request)  # type: ignore
+        formatted_resource_request = formatted_resource_request.dict()["__root__"]
+
+        result = self._request_collection.insert_one(
+            {
+                "request": formatted_resource_request,
+                "status": RequestStatus.PENDING.name,
+                "task_id": self.task_id,
+                "priority": int(priority),
+                "submitted_at": datetime.now(),
+            }
+        )  # DB_ACCESS_OUTSIDE_VIEW
+        _id: ObjectId = cast(ObjectId, result.inserted_id)
+        self._waiting[_id] = {"f": f, "device_str_to_request": device_str_to_request}
+
+        try:
+            result = f.result(timeout=timeout)
+        except TimeoutError:  # cancel the task if timeout
+            self.update_request_status(request_id=_id, status=RequestStatus.CANCELED)
+            raise
+
+        return {
+            **self._post_process_requested_resource(
+                devices=result["devices"],
+                sample_positions=result["sample_positions"],
+                resource_request=resource_request,
+            ),
+            "request_id": result["request_id"],
+        }
+
+    def release_resources(self, request_id: ObjectId) -> bool:
+        """
+        Release a request by request_id
+        """
+        result = self._request_collection.update_one(
+            {
+                "_id": request_id,
+                "status": RequestStatus.FULFILLED.name,
+            },
+            {
+                "$set": {
+                    "status": RequestStatus.NEED_RELEASE.name,
+                }
+            },
+        )
+
+        return result.modified_count == 1
+
+    def release_all_resources(self) -> bool:
+        """
+        Release all requests by task_id, used for error recovery
+
+        For the requests that are not fulfilled, they will be marked as CANCELED.
+
+        For the rewquest that have been fulfilled, they will be marked as NEED_RELEASE.
+        """
+        self._request_collection.update_many(
+            {
+                "task_id": self.task_id,
+                "status": RequestStatus.FULFILLED.name,
+            },
+            {
+                "$set": {
+                    "status": RequestStatus.NEED_RELEASE.name,
+                }
+            },
+        )
+
+        self._request_collection.update_many(
+            {
+                "task_id": self.task_id,
+                "status": RequestStatus.PENDING.name,
+            },
+            {
+                "$set": {
+                    "status": RequestStatus.CANCELED.name,
+                }
+            },
+        )
+
+    def _check_request_status_loop(self):
+        while True:
+            try:
+                for request_id in self._waiting.copy().keys():
+                    status = self.get_request(request_id=request_id, projection=["status"])["status"]  # type: ignore
+                    if status == RequestStatus.FULFILLED.name:
+                        self._handle_fulfilled_request(request_id=request_id)
+                    elif status == RequestStatus.ERROR.name:
+                        self._handle_error_request(request_id=request_id)
+            except Exception:
+                print_exc()  # for debugging in the test
+                raise
+            time.sleep(0.5)
+
+    def _handle_fulfilled_request(self, request_id: ObjectId):
+        entry = self.get_request(request_id)
+        if entry["status"] != RequestStatus.FULFILLED.name:  # type: ignore
+            return
+
+        assigned_devices: Dict[str, Dict[str, Union[str, bool]]] = entry["assigned_devices"]  # type: ignore
+        assigned_sample_positions: Dict[str, List[Dict[str, Any]]] = entry["assigned_sample_positions"]  # type: ignore
+
+        request: Dict[str, Any] = self._waiting.pop(request_id)
+
+        f: Future = request["f"]
+        device_str_to_request: Dict[str, Union[Type[BaseDevice], str, None]] = request[
+            "device_str_to_request"
+        ]
+
+        f.set_result(
+            {
+                "devices": {
+                    device_str_to_request[device_str]: device_dict["name"]
+                    for device_str, device_dict in assigned_devices.items()
+                },
+                "sample_positions": {
+                    name: [
+                        sample_position["name"]
+                        for sample_position in sample_positions_list
+                    ]
+                    for name, sample_positions_list in assigned_sample_positions.items()
+                },
+                "request_id": request_id,
+            }
+        )
+
+    def _handle_error_request(self, request_id: ObjectId):
+        entry = self.get_request(request_id)
+        if entry["status"] != RequestStatus.ERROR.name:  # type: ignore
+            return
+
+        error: Exception = dill.loads(entry["error"])  # type: ignore
+        request: Dict[str, Any] = self._waiting.pop(request_id)
+        f: Future = request["f"]
+        f.set_exception(error)
+
+    @staticmethod
+    def _post_process_requested_resource(
+        devices: Dict[Type[BaseDevice], str],
+        sample_positions: Dict[str, List[str]],
+        resource_request: Dict[str, List[Dict[str, Union[int, str]]]],
+    ):
+        processed_sample_positions: Dict[
+            Optional[Type[BaseDevice]], Dict[str, List[str]]
+        ] = {}
+
+        for device_request, sample_position_dict in resource_request.items():
+            if len(sample_position_dict) == 0:
+                continue
+            processed_sample_positions[device_request] = {}
+            for prefix in sample_position_dict:
+                reply_prefix = prefix
+                if device_request is None:  # no device name to prepend
+                    pass
+                else:
+                    device_prefix = (
+                        f"{devices[device_request]}{SamplePosition.SEPARATOR}"
+                    )
+                    if not reply_prefix.startswith(
+                        device_prefix
+                    ):  # dont extra prepend for nested requests
+                        reply_prefix = device_prefix + reply_prefix
+                processed_sample_positions[device_request][prefix] = sample_positions[
+                    reply_prefix
+                ]
+                # {
+        #     device_request: {
+        #         prefix: sample_positions[prefix] for prefix in sample_position_dict
+        #     }
+        #     for device_request, sample_position_dict in resource_request.items()
+        # }
+        return {
+            "devices": devices,
+            "sample_positions": processed_sample_positions,
+        }

--- a/alab_management/task_manager/task_manager.py
+++ b/alab_management/task_manager/task_manager.py
@@ -22,21 +22,21 @@ from alab_management.logger import LoggingLevel
 from alab_management.sample_view.sample import SamplePosition
 from alab_management.task_view.task import BaseTask
 from alab_management.task_view.task_enums import TaskStatus
-from .device_view import DeviceView
-from .device_view.device import BaseDevice
-from .sample_view import SampleView
-from .sample_view.sample_view import SamplePositionRequest
-from .task_actor import run_task
-from .task_view import TaskView, TaskPriority
-from .utils.data_objects import get_collection
-from .utils.module_ops import load_definition
 
-_SampleRequestDict = Dict[str, int]
-_ResourceRequestDict = Dict[
-    Optional[Union[Type[BaseDevice], str]], List[_SampleRequestDict]
-]  # the raw request sent by task process
-
-_EXTRA_REQUEST: str = "__nodevice"
+from alab_management.lab_view import LabView
+from ..device_view import DeviceView
+from ..device_view.device import BaseDevice
+from ..sample_view import SampleView
+from ..sample_view.sample_view import SamplePositionRequest
+from ..task_actor import run_task
+from ..task_view import TaskView, TaskPriority
+from ..utils.data_objects import get_collection
+from ..utils.module_ops import load_definition
+from .resource_requester import (
+    RequestMixin,
+    RequestStatus,
+)
+from .enums import RequestStatus, _EXTRA_REQUEST
 
 
 def parse_reroute_tasks() -> Dict[str, Type[BaseTask]]:
@@ -97,100 +97,6 @@ def parse_reroute_tasks() -> Dict[str, Type[BaseTask]]:
 _reroute_registry = parse_reroute_tasks()
 
 
-class RequestStatus(Enum):
-    """
-    The status for a request. It will be stored in the database
-    """
-
-    PENDING = auto()
-    FULFILLED = auto()
-    NEED_RELEASE = auto()
-    RELEASED = auto()
-    CANCELED = auto()
-    ERROR = auto()
-
-
-class ResourcesRequest(BaseModel):
-    """
-    This class is used to validate the resource request. Each request should have a format of
-    [
-        {
-            "device":{
-                "identifier": "name" or "type" or "nodevice",
-                "content": string corresponding to identifier
-            },
-            "sample_positions": [
-                {
-                    "prefix": prefix of sample position,
-                    "number": integer number of such positions requested.
-                },
-                ...
-            ]
-        },
-        ...
-    ]
-
-    See Also:
-        :py:class:`SamplePositionRequest <alab_management.sample_view.sample_view.SamplePositionRequest>`
-    """
-
-    __root__: List[
-        Dict[str, Union[List[Dict[str, Union[str, int]]], Dict[str, str]]]
-    ]  # type: ignore
-
-    @root_validator(pre=True, allow_reuse=True)
-    def preprocess(cls, values):  # pylint: disable=no-self-use,no-self-argument
-        values = values["__root__"]
-
-        new_values = []
-        for request_dict in values:
-            if request_dict["device"]["identifier"] not in [
-                "name",
-                "type",
-                _EXTRA_REQUEST,
-            ]:
-                raise ValueError(
-                    f"device identifier must be one of 'name', 'type', or {_EXTRA_REQUEST}"
-                )
-            new_values.append(
-                {
-                    "device": {
-                        "identifier": request_dict["device"]["identifier"],
-                        "content": request_dict["device"]["content"],
-                    },
-                    "sample_positions": request_dict["sample_positions"],
-                }
-            )
-        return {"__root__": new_values}
-
-
-class RequestMixin:
-    """
-    Simple wrapper for the request collection
-    """
-
-    def __init__(self):
-        self._request_collection = get_collection("requests")
-
-    def update_request_status(self, request_id: ObjectId, status: RequestStatus):
-        return self._request_collection.update_one(
-            {"_id": request_id}, {"$set": {"status": status.name}}
-        )
-
-    def get_request(self, request_id: ObjectId, **kwargs):
-        return self._request_collection.find_one(
-            {"_id": request_id}, **kwargs
-        )  # DB_ACCESS_OUTSIDE_VIEW
-
-    def get_requests_by_status(self, status: RequestStatus):
-        return self._request_collection.find(
-            {"status": status.name}
-        )  # DB_ACCESS_OUTSIDE_VIEW
-
-    def get_requests_by_task_id(self, task_id: ObjectId):
-        return self._request_collection.find({"task_id": task_id})
-
-
 class TaskManager(RequestMixin):
     """
     TaskManager will
@@ -213,6 +119,8 @@ class TaskManager(RequestMixin):
         """
         Start the loop
         """
+        self._clean_up_tasks_from_previous_runs()
+
         while True:
             self._loop()
             time.sleep(2)
@@ -225,6 +133,39 @@ class TaskManager(RequestMixin):
 
         if not self.__reroute_in_progress:
             self.handle_request_cycles()
+
+    def _clean_up_tasks_from_previous_runs(self):
+        """Cleans up incomplete tasks that exist from the last time the taskmanager was running. Note that this will block the task queue until all samples in these tasks have been removed from the physical lab (confirmed via user requests on the dashboard).
+
+        This typically occurs if the taskmanager was exited using SIGTERM (ctrl-c), in which case some tasks may still be in the RUNNING or CANCELLING state. These will be set to CANCELLED now.
+        """
+
+        tasks_to_cancel = self.task_view.get_tasks_by_status(TaskStatus.RUNNING)
+        tasks_to_cancel += self.task_view.get_tasks_by_status(TaskStatus.CANCELLING)
+
+        if len(tasks_to_cancel) == 0:
+            print("No dangling tasks found from previous alabos workers. Nice!")
+            return
+
+        print(
+            f"""
+              Found {len(tasks_to_cancel)} dangling tasks leftover from previous alabos workers. These tasks were in an unknown state (RUNNING or CANCELLING) when the alabos workers were stopped. 
+              
+              We will now cancel them and remove their physical components from the lab. We will go through each task one by one. A user request will appear on the alabos dashboard for each task. Please acknowledge each request to remove the samples from the lab. Once all tasks have been addressed, the alabos workers will begin to process new tasks. Thanks!
+              """
+        )
+        for i, task_entry in enumerate(tasks_to_cancel):
+            task_id = task_entry["_id"]
+            task_name = task_entry["type"]
+            print(
+                f"({i+1}/{len(tasks_to_cancel)}) please clean up the {task_name} task on the ALabOS dashboard."
+            )
+
+            # puts a user request on the dashboard to remove all samples in this task from the physical lab, blocks until request is acknowledged. There may be a duplicate request on the dashboard if the task was already cancelled before the taskmanager was restarted. Acknowledging both should be fine.
+            LabView(task_id=task_id).request_cleanup()
+
+            # mark task as successfully cancelled
+            self.task_view.update_status(task_id=task_id, status=TaskStatus.CANCELLED)
 
     def submit_ready_tasks(self):
         """
@@ -333,7 +274,6 @@ class TaskManager(RequestMixin):
                     prefix = pos["prefix"]
                     # if this is a nested resource request, lets not prepend the device name twice.
                     if not prefix.startswith(device_prefix):
-
                         prefix = device_prefix + prefix
                     parsed_sample_positions_request.append(
                         SamplePositionRequest(prefix=prefix, number=pos["number"])
@@ -483,7 +423,7 @@ class TaskManager(RequestMixin):
 
         # get the highest priority task in the cycle. We will unblock this task.
         highest_priority = -inf
-        for (_blocking_taskid, _occupying_taskid) in cycle:
+        for _blocking_taskid, _occupying_taskid in cycle:
             priority = task_priority[_blocking_taskid]
             if priority > highest_priority:
                 highest_priority = priority
@@ -543,255 +483,3 @@ class TaskManager(RequestMixin):
                 sample=sample_to_move["_id"],
             ).run()
         self.__reroute_in_progress = False
-
-
-class ResourceRequester(RequestMixin):
-    """
-    Class for request lab resources easily. This class will insert a request into the database,
-    and then the task manager will read from the database and assign the resources.
-
-    It is used in :py:class:`~alab_management.lab_view.LabView`.
-    """
-
-    def __init__(
-        self,
-        task_id: ObjectId,
-    ):
-        self._request_collection = get_collection("requests")
-        self._waiting: Dict[ObjectId, Dict[str, Any]] = {}
-        self.task_id = task_id
-        self.priority: Union[
-            int, TaskPriority
-        ] = (
-            TaskPriority.NORMAL
-        )  # will usually be overwritten by BaseTask instantiation.
-
-        super().__init__()
-        self._thread = Thread(target=self._check_request_status_loop)
-        self._thread.daemon = False
-        self._thread.start()
-
-    def request_resources(
-        self,
-        resource_request: _ResourceRequestDict,
-        timeout: Optional[float] = None,
-        priority: Optional[Union[TaskPriority, int]] = None,
-    ) -> Dict[str, Any]:
-        """
-        Request lab resources. Write the request into the database, and then the task manager will read from the
-        database and assign the resources.
-        """
-
-        f = Future()
-        if priority is None:
-            priority = self.priority
-
-        formatted_resource_request = []
-
-        device_str_to_request = {}
-        for device, position_dict in resource_request.items():
-            if device is None:
-                identifier = _EXTRA_REQUEST
-                content = _EXTRA_REQUEST
-            elif isinstance(device, str):
-                identifier = "name"
-                content = device
-            elif issubclass(device, BaseDevice):
-                identifier = "type"
-                content = device.__name__
-            else:
-                raise ValueError(
-                    "device must be a name of a specific device, a class of type BaseDevice, or None"
-                )
-            device_str_to_request[content] = device
-
-            positions = [
-                dict(SamplePositionRequest(prefix=prefix, number=number))
-                for prefix, number in position_dict.items()
-            ]  # immediate dict conversion - SamplePositionRequest is only used to check request format.
-            formatted_resource_request.append(
-                {
-                    "device": {
-                        "identifier": identifier,
-                        "content": content,
-                    },
-                    "sample_positions": positions,
-                }
-            )
-
-        if not isinstance(formatted_resource_request, ResourcesRequest):
-            formatted_resource_request = ResourcesRequest(__root__=formatted_resource_request)  # type: ignore
-        formatted_resource_request = formatted_resource_request.dict()["__root__"]
-
-        result = self._request_collection.insert_one(
-            {
-                "request": formatted_resource_request,
-                "status": RequestStatus.PENDING.name,
-                "task_id": self.task_id,
-                "priority": int(priority),
-                "submitted_at": datetime.now(),
-            }
-        )  # DB_ACCESS_OUTSIDE_VIEW
-        _id: ObjectId = cast(ObjectId, result.inserted_id)
-        self._waiting[_id] = {"f": f, "device_str_to_request": device_str_to_request}
-
-        try:
-            result = f.result(timeout=timeout)
-        except TimeoutError:  # cancel the task if timeout
-            self.update_request_status(request_id=_id, status=RequestStatus.CANCELED)
-            raise
-
-        return {
-            **self._post_process_requested_resource(
-                devices=result["devices"],
-                sample_positions=result["sample_positions"],
-                resource_request=resource_request,
-            ),
-            "request_id": result["request_id"],
-        }
-
-    def release_resources(self, request_id: ObjectId) -> bool:
-        """
-        Release a request by request_id
-        """
-        result = self._request_collection.update_one(
-            {
-                "_id": request_id,
-                "status": RequestStatus.FULFILLED.name,
-            },
-            {
-                "$set": {
-                    "status": RequestStatus.NEED_RELEASE.name,
-                }
-            },
-        )
-
-        return result.modified_count == 1
-
-    def release_all_resources(self) -> bool:
-        """
-        Release all requests by task_id, used for error recovery
-
-        For the requests that are not fulfilled, they will be marked as CANCELED.
-
-        For the rewquest that have been fulfilled, they will be marked as NEED_RELEASE.
-        """
-        self._request_collection.update_many(
-            {
-                "task_id": self.task_id,
-                "status": RequestStatus.FULFILLED.name,
-            },
-            {
-                "$set": {
-                    "status": RequestStatus.NEED_RELEASE.name,
-                }
-            },
-        )
-
-        self._request_collection.update_many(
-            {
-                "task_id": self.task_id,
-                "status": RequestStatus.PENDING.name,
-            },
-            {
-                "$set": {
-                    "status": RequestStatus.CANCELED.name,
-                }
-            },
-        )
-
-    def _check_request_status_loop(self):
-        while True:
-            try:
-                for request_id in self._waiting.copy().keys():
-                    status = self.get_request(request_id=request_id, projection=["status"])["status"]  # type: ignore
-                    if status == RequestStatus.FULFILLED.name:
-                        self._handle_fulfilled_request(request_id=request_id)
-                    elif status == RequestStatus.ERROR.name:
-                        self._handle_error_request(request_id=request_id)
-            except Exception:
-                print_exc()  # for debugging in the test
-                raise
-            time.sleep(0.5)
-
-    def _handle_fulfilled_request(self, request_id: ObjectId):
-        entry = self.get_request(request_id)
-        if entry["status"] != RequestStatus.FULFILLED.name:  # type: ignore
-            return
-
-        assigned_devices: Dict[str, Dict[str, Union[str, bool]]] = entry["assigned_devices"]  # type: ignore
-        assigned_sample_positions: Dict[str, List[Dict[str, Any]]] = entry["assigned_sample_positions"]  # type: ignore
-
-        request: Dict[str, Any] = self._waiting.pop(request_id)
-
-        f: Future = request["f"]
-        device_str_to_request: Dict[str, Union[Type[BaseDevice], str, None]] = request[
-            "device_str_to_request"
-        ]
-
-        f.set_result(
-            {
-                "devices": {
-                    device_str_to_request[device_str]: device_dict["name"]
-                    for device_str, device_dict in assigned_devices.items()
-                },
-                "sample_positions": {
-                    name: [
-                        sample_position["name"]
-                        for sample_position in sample_positions_list
-                    ]
-                    for name, sample_positions_list in assigned_sample_positions.items()
-                },
-                "request_id": request_id,
-            }
-        )
-
-    def _handle_error_request(self, request_id: ObjectId):
-        entry = self.get_request(request_id)
-        if entry["status"] != RequestStatus.ERROR.name:  # type: ignore
-            return
-
-        error: Exception = dill.loads(entry["error"])  # type: ignore
-        request: Dict[str, Any] = self._waiting.pop(request_id)
-        f: Future = request["f"]
-        f.set_exception(error)
-
-    @staticmethod
-    def _post_process_requested_resource(
-        devices: Dict[Type[BaseDevice], str],
-        sample_positions: Dict[str, List[str]],
-        resource_request: Dict[str, List[Dict[str, Union[int, str]]]],
-    ):
-        processed_sample_positions: Dict[
-            Optional[Type[BaseDevice]], Dict[str, List[str]]
-        ] = {}
-
-        for device_request, sample_position_dict in resource_request.items():
-            if len(sample_position_dict) == 0:
-                continue
-            processed_sample_positions[device_request] = {}
-            for prefix in sample_position_dict:
-                reply_prefix = prefix
-                if device_request is None:  # no device name to prepend
-                    pass
-                else:
-                    device_prefix = (
-                        f"{devices[device_request]}{SamplePosition.SEPARATOR}"
-                    )
-                    if not reply_prefix.startswith(
-                        device_prefix
-                    ):  # dont extra prepend for nested requests
-                        reply_prefix = device_prefix + reply_prefix
-                processed_sample_positions[device_request][prefix] = sample_positions[
-                    reply_prefix
-                ]
-                # {
-        #     device_request: {
-        #         prefix: sample_positions[prefix] for prefix in sample_position_dict
-        #     }
-        #     for device_request, sample_position_dict in resource_request.items()
-        # }
-        return {
-            "devices": devices,
-            "sample_positions": processed_sample_positions,
-        }

--- a/alab_management/task_view/task_view.py
+++ b/alab_management/task_view/task_view.py
@@ -124,6 +124,8 @@ class TaskView:
             task_id: the task_id of interest. If not found, will return ``None``
             encode: whether to encode the task using ``self.encode_task`` method
         """
+        task_id = ObjectId(task_id)
+
         result = self._task_collection.find_one({"_id": task_id})
 
         if result is None:

--- a/alab_management/utils/module_ops.py
+++ b/alab_management/utils/module_ops.py
@@ -8,6 +8,7 @@ import re
 import sys
 from pathlib import Path
 from typing import Optional, Union
+from copy import copy
 
 
 def import_module_from_path(
@@ -40,12 +41,14 @@ def load_definition():
     config = AlabConfig()
     working_dir = config["general"]["working_dir"]
     parent_package = config["general"].get("parent_package", None)
-    if os.path.isabs(working_dir):
-        working_dir = Path(working_dir)
-    else:
-        working_dir = config.path.parent / working_dir
 
-    import_module_from_path(working_dir, parent_package)
+    dir_to_import_from = copy(working_dir)
+    if os.path.isabs(dir_to_import_from):
+        dir_to_import_from = Path(dir_to_import_from)
+    else:
+        dir_to_import_from = config.path.parent / dir_to_import_from
+
+    import_module_from_path(dir_to_import_from, parent_package)
 
 
 # def import_device_definitions(file_folder: str, module_name: str):


### PR DESCRIPTION
This adds a cleanup step that runs whenever `alabos launch_worker` is run from the command line. This step runs before the task actors are started -- no new tasks are run until the cleanup is complete

1. Looks for any tasks that are `TaskStatus.RUNNING` or `TaskStatus.CANCELLING`. These tasks were not in a clean state when we last stopped our task actors. Normally, these statuses are only present for tasks that are actively being handled by a dramatiq task actor.
2. For each task, we push a user request to alabos dashboard. This request tells the user what lab resources (samples, samplepositions) need to be cleared to remove this task from the physical lab. Once the user acknowledges the request, we move to the next abandoned task until all are cleaned up
3. Proceeds to spawn new task actor threads to handle new tasks.