### PR TITLE
Add `SampleView.update_sample_metadata()`, plus a test

### DIFF
--- a/tests/test_sample_view.py
+++ b/tests/test_sample_view.py
@@ -9,9 +9,7 @@ from alab_management.scripts.cleanup_lab import cleanup_lab
 from alab_management.scripts.setup_lab import setup_lab
 
 
-def occupy_sample_positions(
-    sample_positions, sample_view: SampleView, task_id: ObjectId
-):
+def occupy_sample_positions(sample_positions, sample_view: SampleView, task_id: ObjectId):
     for sample_positions_ in sample_positions.values():
         for sample_position_ in sample_positions_:
             sample_view.lock_sample_position(task_id, sample_position_["name"])
@@ -48,29 +46,18 @@ class TestSampleView(TestCase):
         self.sample_view._sample_collection.drop()
 
     @contextmanager
-    def request_sample_positions(
-        self, sample_positions_list, task_id: ObjectId, _timeout=None
-    ):
+    def request_sample_positions(self, sample_positions_list, task_id: ObjectId, _timeout=None):
         cnt = 0
-        sample_positions = self.sample_view.request_sample_positions(
-            task_id=task_id, sample_positions=sample_positions_list
-        )
-        while (
-            _timeout is not None and sample_positions is None and _timeout >= cnt / 10
-        ):
-            sample_positions = self.sample_view.request_sample_positions(
-                task_id=task_id, sample_positions=sample_positions_list
-            )
+        sample_positions = self.sample_view.request_sample_positions(task_id=task_id, sample_positions=sample_positions_list)
+        while _timeout is not None and sample_positions is None and _timeout >= cnt / 10:
+            sample_positions = self.sample_view.request_sample_positions(task_id=task_id, sample_positions=sample_positions_list)
             cnt += 1
             time.sleep(0.1)
 
         if sample_positions is not None:
             occupy_sample_positions(sample_positions, self.sample_view, task_id)
         yield (
-            {
-                prefix: [sp["name"] for sp in sps]
-                for prefix, sps in sample_positions.items()
-            }
+            {prefix: [sp["name"] for sp in sps] for prefix, sps in sample_positions.items()}
             if sample_positions is not None
             else None
         )
@@ -102,6 +89,16 @@ class TestSampleView(TestCase):
         with self.assertRaises(ValueError):
             self.sample_view.get_sample(sample_id=ObjectId())
 
+    def test_update_sample_metadata(self):
+        sample_id = self.sample_view.create_sample("test_sample", position=None, metadata={"test_param": "test_value"})
+        self.sample_view.update_sample_metadata(sample_id=sample_id, metadata={"test_param2": "test_value2"})
+        sample = self.sample_view.get_sample(sample_id=sample_id)
+        self.assertDictEqual({"test_param": "test_value", "test_param2": "test_value2"}, sample.metadata)
+
+        # try to update a non-exist sample
+        with self.assertRaises(ValueError):
+            self.sample_view.update_sample_metadata(sample_id=ObjectId(), metadata={"test_param": "test_value"})
+
     def test_move_sample(self):
         sample_id = self.sample_view.create_sample("test", position=None)
         sample_id_2 = self.sample_view.create_sample("test", position=None)
@@ -126,9 +123,7 @@ class TestSampleView(TestCase):
 
         # try to move a sample to an occupied position
         with self.assertRaises(ValueError):
-            self.sample_view.move_sample(
-                sample_id=sample_id_2, position="furnace_table"
-            )
+            self.sample_view.move_sample(sample_id=sample_id_2, position="furnace_table")
         sample_2 = self.sample_view.get_sample(sample_id=sample_id_2)
         self.assertEqual(None, sample_2.position)
 
@@ -149,9 +144,7 @@ class TestSampleView(TestCase):
             "LOCKED",
             self.sample_view.get_sample_position_status("furnace_table")[0].name,
         )
-        self.assertListEqual(
-            ["furnace_table"], self.sample_view.get_sample_positions_by_task(task_id)
-        )
+        self.assertListEqual(["furnace_table"], self.sample_view.get_sample_positions_by_task(task_id))
 
         self.sample_view.release_sample_position("furnace_table")
 
@@ -159,9 +152,7 @@ class TestSampleView(TestCase):
 
         # try to lock a sample position that already has a sample
         with self.assertRaises(ValueError):
-            self.sample_view.lock_sample_position(
-                task_id=task_id, position="furnace_table"
-            )
+            self.sample_view.lock_sample_position(task_id=task_id, position="furnace_table")
 
         # try to lock a sample position with a sample that has the same task id
         self.sample_view.update_sample_task_id(sample_id=sample_id, task_id=task_id)
@@ -194,17 +185,13 @@ class TestSampleView(TestCase):
     def test_request_sample_position_single(self):
         task_id = ObjectId()
 
-        with self.request_sample_positions(
-            ["furnace_table", "furnace_1/inside"], task_id
-        ) as sample_positions:
+        with self.request_sample_positions(["furnace_table", "furnace_1/inside"], task_id) as sample_positions:
             self.assertFalse(sample_positions is None)
             for sample_position_prefix, sample_position in sample_positions.items():
                 self.assertTrue(sample_position[0].startswith(sample_position_prefix))
                 self.assertEqual(
                     "LOCKED",
-                    self.sample_view.get_sample_position_status(sample_position[0])[
-                        0
-                    ].name,
+                    self.sample_view.get_sample_position_status(sample_position[0])[0].name,
                 )
                 self.assertEqual(
                     task_id,
@@ -216,21 +203,15 @@ class TestSampleView(TestCase):
                 "EMPTY",
                 self.sample_view.get_sample_position_status(sample_position[0])[0].name,
             )
-            self.assertEqual(
-                None, self.sample_view.get_sample_position_status(sample_position[0])[1]
-            )
+            self.assertEqual(None, self.sample_view.get_sample_position_status(sample_position[0])[1])
 
     def test_request_device_timeout(self):
         task_id = ObjectId()
         task_id_2 = ObjectId()
 
-        with self.request_sample_positions(
-            ["furnace_table", "furnace_1/inside"], task_id
-        ) as sample_positions:
+        with self.request_sample_positions(["furnace_table", "furnace_1/inside"], task_id) as sample_positions:
             self.assertFalse(sample_positions is None)
-            with self.request_sample_positions(
-                ["furnace_table", "furnace_1/inside"], task_id_2
-            ) as _sample_positions:
+            with self.request_sample_positions(["furnace_table", "furnace_1/inside"], task_id_2) as _sample_positions:
                 self.assertIs(None, _sample_positions)
 
     def test_request_sample_positions_twice(self):
@@ -256,9 +237,7 @@ class TestSampleView(TestCase):
                 "LOCKED",
                 self.sample_view.get_sample_position_status("furnace_temp/1")[0].name,
             )
-            with self.request_sample_positions(
-                ["furnace_table", "furnace_temp/1"], task_id
-            ) as sample_positions_:
+            with self.request_sample_positions(["furnace_table", "furnace_temp/1"], task_id) as sample_positions_:
                 self.assertDictEqual(
                     {
                         "furnace_table": ["furnace_table"],
@@ -268,28 +247,18 @@ class TestSampleView(TestCase):
                 )
                 self.assertEqual(
                     "LOCKED",
-                    self.sample_view.get_sample_position_status("furnace_table")[
-                        0
-                    ].name,
+                    self.sample_view.get_sample_position_status("furnace_table")[0].name,
                 )
-                with self.request_sample_positions(
-                    ["furnace_table"], task_id
-                ) as sample_positions__:
-                    self.assertDictEqual(
-                        {"furnace_table": ["furnace_table"]}, sample_positions__
-                    )
+                with self.request_sample_positions(["furnace_table"], task_id) as sample_positions__:
+                    self.assertDictEqual({"furnace_table": ["furnace_table"]}, sample_positions__)
                     self.assertEqual(
                         "LOCKED",
-                        self.sample_view.get_sample_position_status("furnace_table")[
-                            0
-                        ].name,
+                        self.sample_view.get_sample_position_status("furnace_table")[0].name,
                     )
 
                 self.assertEqual(
                     "LOCKED",
-                    self.sample_view.get_sample_position_status("furnace_table")[
-                        0
-                    ].name,
+                    self.sample_view.get_sample_position_status("furnace_table")[0].name,
                 )
 
             self.assertEqual(
@@ -301,9 +270,7 @@ class TestSampleView(TestCase):
             "EMPTY",
             self.sample_view.get_sample_position_status("furnace_table")[0].name,
         )
-        self.assertEqual(
-            None, self.sample_view.get_sample_position_status("furnace_table")[1]
-        )
+        self.assertEqual(None, self.sample_view.get_sample_position_status("furnace_table")[1])
 
     def test_request_sample_positions_occupied(self):
         task_id = ObjectId()
@@ -320,97 +287,63 @@ class TestSampleView(TestCase):
 
         self.sample_view.update_sample_task_id(sample_id, task_id)
 
-        with self.request_sample_positions(
-            ["furnace_table", "furnace_1/inside"], task_id
-        ):
+        with self.request_sample_positions(["furnace_table", "furnace_1/inside"], task_id):
             self.assertEqual(
                 "OCCUPIED",
                 self.sample_view.get_sample_position_status("furnace_table")[0].name,
             )
-            self.assertEqual(
-                task_id, self.sample_view.get_sample_position_status("furnace_table")[1]
-            )
+            self.assertEqual(task_id, self.sample_view.get_sample_position_status("furnace_table")[1])
 
         self.assertEqual(
             "OCCUPIED",
             self.sample_view.get_sample_position_status("furnace_table")[0].name,
         )
-        self.assertEqual(
-            None, self.sample_view.get_sample_position("furnace_table")["task_id"]
-        )
+        self.assertEqual(None, self.sample_view.get_sample_position("furnace_table")["task_id"])
 
     def test_request_multiple_sample_positions(self):
         task_id = ObjectId()
 
         for j in range(1, 5):
-            with self.request_sample_positions(
-                [{"prefix": "furnace_temp", "number": j}], task_id
-            ) as sample_positions:
+            with self.request_sample_positions([{"prefix": "furnace_temp", "number": j}], task_id) as sample_positions:
                 self.assertFalse(sample_positions is None)
                 for sample_position_prefix, sample_position in sample_positions.items():
                     for i in range(j):
-                        self.assertTrue(
-                            sample_position[i].startswith(sample_position_prefix)
-                        )
+                        self.assertTrue(sample_position[i].startswith(sample_position_prefix))
                         self.assertEqual(
                             "LOCKED",
-                            self.sample_view.get_sample_position_status(
-                                sample_position[i]
-                            )[0].name,
+                            self.sample_view.get_sample_position_status(sample_position[i])[0].name,
                         )
                         self.assertEqual(
                             task_id,
-                            self.sample_view.get_sample_position_status(
-                                sample_position[i]
-                            )[1],
+                            self.sample_view.get_sample_position_status(sample_position[i])[1],
                         )
 
             for sample_position in sample_positions.values():
                 for i in range(j):
                     self.assertEqual(
                         "EMPTY",
-                        self.sample_view.get_sample_position_status(sample_position[i])[
-                            0
-                        ].name,
+                        self.sample_view.get_sample_position_status(sample_position[i])[0].name,
                     )
                     self.assertEqual(
                         None,
-                        self.sample_view.get_sample_position_status(sample_position[i])[
-                            1
-                        ],
+                        self.sample_view.get_sample_position_status(sample_position[i])[1],
                     )
 
         # try when requesting sample positions more than we have in the lab
-        with self.assertRaises(ValueError), self.request_sample_positions(
-            [{"prefix": "furnace_temp", "number": 5}], task_id
-        ):
+        with self.assertRaises(ValueError), self.request_sample_positions([{"prefix": "furnace_temp", "number": 5}], task_id):
             pass
 
     def test_request_multiple_sample_positions_multiple_tasks(self):
         task_id_1 = ObjectId()
         task_id_2 = ObjectId()
 
-        with self.request_sample_positions(
-            [{"prefix": "furnace_temp", "number": 2}], task_id_1
-        ) as sample_positions:
+        with self.request_sample_positions([{"prefix": "furnace_temp", "number": 2}], task_id_1) as sample_positions:
             self.assertEqual(2, len(sample_positions["furnace_temp"]))
-            self.assertTrue(
-                sample_positions["furnace_temp"][0].startswith("furnace_temp")
-            )
-            self.assertTrue(
-                sample_positions["furnace_temp"][1].startswith("furnace_temp")
-            )
-            with self.request_sample_positions(
-                [{"prefix": "furnace_temp", "number": 2}], task_id_2
-            ) as sample_positions_:
+            self.assertTrue(sample_positions["furnace_temp"][0].startswith("furnace_temp"))
+            self.assertTrue(sample_positions["furnace_temp"][1].startswith("furnace_temp"))
+            with self.request_sample_positions([{"prefix": "furnace_temp", "number": 2}], task_id_2) as sample_positions_:
                 self.assertEqual(2, len(sample_positions_["furnace_temp"]))
-                self.assertTrue(
-                    sample_positions_["furnace_temp"][0].startswith("furnace_temp")
-                )
-                self.assertTrue(
-                    sample_positions_["furnace_temp"][1].startswith("furnace_temp")
-                )
-            with self.request_sample_positions(
-                [{"prefix": "furnace_temp", "number": 4}], task_id_2
-            ) as sample_positions_:
+                self.assertTrue(sample_positions_["furnace_temp"][0].startswith("furnace_temp"))
+                self.assertTrue(sample_positions_["furnace_temp"][1].startswith("furnace_temp"))
+            with self.request_sample_positions([{"prefix": "furnace_temp", "number": 4}], task_id_2) as sample_positions_:
                 self.assertIs(None, sample_positions_)


### PR DESCRIPTION
## Summary

Added a function for updating a `Sample`'s metadata via the `SampleView` class.

This is introduced so that we can include metadata from tasks in the sample database. See #56 

- [x] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/).
  The easiest way to handle this is to run the following in the **correct sequence** on
  your local machine. Start with running [black](
  https://black.readthedocs.io/en/stable/index.html) on your new code. This will
  automatically reformat your code to PEP8 conventions and removes most issues. Then run
  [pycodestyle](https://pycodestyle.readthedocs.io/en/latest/), followed by [flake8](
  http://flake8.pycqa.org/en/latest/).
- [x] Docstrings have been added in the[Numpy docstring format](
  https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html).
  Run [pydocstyle](http://www.pydocstyle.org/en/2.1.1/index.html) on your code.
- [x] Type annotations are **highly** encouraged. Run [mypy](http://mypy-lang.org/) to
  type check your code.
- [x] Tests have been added for any new functionality or bug fixes.
- [x] All linting and tests pass.
